### PR TITLE
docs: Custom Stack Quick Start example missing name param when calling helloWorld function

### DIFF
--- a/pages/quickstart/custom-stack.mdx
+++ b/pages/quickstart/custom-stack.mdx
@@ -174,11 +174,11 @@ Whenever you choose to use the `helloWorld()` function or create your own, the f
 
 ```tsx filename="src/api.ts" {2, 5}
 import http from "http";
-import helloWorld from "..//defer/helloWorld";
+import helloWorld from "../defer/helloWorld";
 
 http
   .createServer(async function (req, res) {
-    await helloWorld();
+    await helloWorld(req.query.name || "World");
     res.write("Hello World!");
     res.end();
   })

--- a/pages/quickstart/custom-stack.mdx
+++ b/pages/quickstart/custom-stack.mdx
@@ -179,6 +179,7 @@ import helloWorld from "../defer/helloWorld";
 http
   .createServer(async function (req, res) {
     await helloWorld(req.query.name || "World");
+
     res.writeHead(200, {"Content-Type": "text/html"});
     res.write(JSON.stringify({ ok: true }));
     res.end();

--- a/pages/quickstart/custom-stack.mdx
+++ b/pages/quickstart/custom-stack.mdx
@@ -179,7 +179,7 @@ import helloWorld from "../defer/helloWorld";
 http
   .createServer(async function (req, res) {
     await helloWorld(req.query.name || "World");
-    response.writeHead(200, {"Content-Type": "text/html"});
+    res.writeHead(200, {"Content-Type": "text/html"});
     res.write(JSON.stringify({ ok: true }));
     res.end();
   })

--- a/pages/quickstart/custom-stack.mdx
+++ b/pages/quickstart/custom-stack.mdx
@@ -179,7 +179,8 @@ import helloWorld from "../defer/helloWorld";
 http
   .createServer(async function (req, res) {
     await helloWorld(req.query.name || "World");
-    res.write("Hello World!");
+    response.writeHead(200, {"Content-Type": "text/html"});
+    res.write(JSON.stringify({ ok: true }));
     res.end();
   })
   .listen(8080);


### PR DESCRIPTION
In the `https://docs.defer.run/quickstart/custom-stack/` Custom Stack example, the `helloWorld` function takes a `name` so that the background function with output `Hello <name>~`:

```ts
// the `defer()` helper will be used to define a background function
import { defer } from "@defer/client";
 
// a background function must be `async`
async function helloWorld(name: string) {
  return new Promise((resolve) => {
    setTimeout(() => {
      console.log(`Hello ${name}!`);  // <--- see here
      resolve("done");
    }, 5000);
  });
}
 
// the function must be wrapped with `defer()` and exported as default
export default defer(helloWorld);
```

But,  when invoked in `await helloWorld(); ` no name is given:

```ts
import http from "http";
import helloWorld from "..//defer/helloWorld";
 
http
  .createServer(async function (req, res) {
    await helloWorld(); // <-- see here
    res.write("Hello World!");
    res.end();
  })
  .listen(8080);
```


This PR suggests that the name param could be extracted from the request to output "Hello .." dynamically.

Note: The response stays `res.write("Hello World!");` so you can see that the function returns something, but the job does something else. I could see they should show the same perhaps?
